### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/alice-blog-checker.yml
+++ b/.github/workflows/alice-blog-checker.yml
@@ -5,6 +5,9 @@ on:
     - cron: '30 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   alice_blog_checker:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-forum.yaml
+++ b/.github/workflows/daily-forum.yaml
@@ -5,6 +5,9 @@ on:
     - cron: "5 15 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   fetch-data-and-create-forum:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-notify-popular-product.yml
+++ b/.github/workflows/daily-notify-popular-product.yml
@@ -1,5 +1,8 @@
 name: Notify Popular Products
 
+permissions:
+  contents: read
+
 on:
   schedule:
    - cron: '58 23 * * *'

--- a/.github/workflows/daily-notify-popular-repositories.yml
+++ b/.github/workflows/daily-notify-popular-repositories.yml
@@ -5,6 +5,9 @@ on:
     - cron: '58 23 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-notify-start.yml
+++ b/.github/workflows/daily-notify-start.yml
@@ -5,6 +5,9 @@ on:
     - cron: '10 15 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run-dify-workflow:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-role-remove.yml
+++ b/.github/workflows/daily-role-remove.yml
@@ -5,6 +5,9 @@ on:
   #   - cron: "0 15 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   discord_daily_role_remove:
     runs-on: ubuntu-latest

--- a/.github/workflows/delete_workflow_runs.yml
+++ b/.github/workflows/delete_workflow_runs.yml
@@ -8,6 +8,10 @@ on:
         required: true
         default: '1'
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   delete_runs:
     runs-on: ubuntu-latest

--- a/.github/workflows/fetch-rss.yml
+++ b/.github/workflows/fetch-rss.yml
@@ -1,5 +1,8 @@
 name: Fetch RSS Feeds
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '*/15 * * * *'

--- a/.github/workflows/send-beautiful-view.yml
+++ b/.github/workflows/send-beautiful-view.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   send_beautiful_view:
     runs-on: ubuntu-latest

--- a/.github/workflows/send-cat-and-wiki.yml
+++ b/.github/workflows/send-cat-and-wiki.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   send_cat_and_wiki:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/clockcrockwork/cccDataImporter/security/code-scanning/10](https://github.com/clockcrockwork/cccDataImporter/security/code-scanning/10)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is the minimal permission required for most workflows. Since the workflow does not perform any actions requiring write permissions, this change will restrict the `GITHUB_TOKEN` to read-only access, enhancing security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
