### PR TITLE
Introduce Discord HTTP client and wiki disambiguation resolver; refactor senders and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,4 @@ dist
 
 # Dev IDX
 .idx
-.idx/*
+.idx/*packages/sendPy/tests/__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,5 @@ dist
 
 # Dev IDX
 .idx
-.idx/*packages/sendPy/tests/__pycache__/
+.idx/*
+__pycache__/

--- a/packages/aliceBlogChecker/src/index.js
+++ b/packages/aliceBlogChecker/src/index.js
@@ -85,18 +85,12 @@ const checkAndUpdateFeeds = async (feeds) => {
       
       // 日付文字列を解析して適切なDateTimeオブジェクトを作成する関数
       const parseDate = (dateString) => {
-        let dateTime;
-        try {
-          dateTime = DateTime.fromRFC2822(dateString).setZone(timezone);
-        } catch (e) {
-          try {
-            dateTime = DateTime.fromISO(dateString).setZone(timezone);
-          } catch (e) {
-            console.error('Invalid date format:', e.message);
-            return null;
-          }
-        }
-        return dateTime;
+        let dateTime = DateTime.fromRFC2822(dateString).setZone(timezone);
+        if (dateTime.isValid) return dateTime;
+        dateTime = DateTime.fromISO(dateString).setZone(timezone);
+        if (dateTime.isValid) return dateTime;
+        console.error('Invalid date format:', dateString);
+        return null;
       };
       const latestPubdate = parseDate(pubdateString);
       if (!latestPubdate) {

--- a/packages/aliceBlogChecker/src/index.js
+++ b/packages/aliceBlogChecker/src/index.js
@@ -26,8 +26,6 @@ const timezone = 'Asia/Tokyo';
 
 async function handleError(error) {
   const ERROR_WEBHOOK_URL = process.env.ERROR_WEBHOOK_URL;
-  const GH_TOKEN = process.env.GH_TOKEN;
-  const GITHUB_REPO = process.env.GITHUB_REPO;
 
   // エラーがオブジェクトの場合、messageとstackを取り出す
   if (error instanceof Error) {
@@ -59,24 +57,6 @@ async function handleError(error) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ content: `【Alice Blog Check】Error: ${error.message}` })
   });
-  // const sanitizedError = {
-  //     message: error.message.replace(/https?:\/\/\S+/g, '[REDACTED URL]').replace(/\b\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\b/g, '[REDACTED ID]'),
-  //     stack: error.stack ? error.stack.replace(/https?:\/\/\S+/g, '[REDACTED URL]').replace(/\b\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\b/g, '[REDACTED ID]') : 'No stack trace available'
-  // };
-  // await fetch(
-  //     `https://api.github.com/repos/${GITHUB_REPO}/issues`,
-  //     {
-  //         method: 'POST',
-  //         headers: {
-  //             'Content-Type': 'application/json',
-  //             'Authorization': `token ${GH_TOKEN}`
-  //         },
-  //         body: JSON.stringify({
-  //             title: `ALICE Channel Error: ${sanitizedError.message}`,
-  //             body: sanitizedError.stack,
-  //         })
-  //     }
-  // );
 }
 
 const fetchFeeds = async () => {
@@ -112,7 +92,7 @@ const checkAndUpdateFeeds = async (feeds) => {
           try {
             dateTime = DateTime.fromISO(dateString).setZone(timezone);
           } catch (e) {
-            handleError('Invalid date format:' + e.message);
+            console.error('Invalid date format:', e.message);
             return null;
           }
         }
@@ -265,7 +245,7 @@ const postRandomImageToDiscord = async (webhook) => {
       throw new Error(`Failed to send message: ${discordResponse.status}`);
     }
   } catch (error) {
-    handleError(error);
+    await handleError(error);
   }
 };
 

--- a/packages/fetchRss/src/index.js
+++ b/packages/fetchRss/src/index.js
@@ -181,7 +181,7 @@ async function processFeeds(feeds, concurrencyLimit = 5) {
     results.push(...batchResults.filter(result => result.status === 'fulfilled').map(result => result.value));
   }
 
-  return results;
+  return { results, errors: errors.getErrors() };
 }
 
 async function processFeed(feed, errors) {
@@ -259,7 +259,8 @@ async function main() {
     try {
         const accessToken = await authenticateUser();
         const feeds = await getRssFeeds();
-        const results = await processFeeds(feeds);
+        const { results, errors: feedErrors } = await processFeeds(feeds);
+        feedErrors.forEach(err => errors.addError(err));
 
         const updates = results.flatMap(result => result.updates);
         const notifications = results.flatMap(result => result.notifications).reverse();

--- a/packages/fetchRss/src/index.js
+++ b/packages/fetchRss/src/index.js
@@ -92,7 +92,7 @@ async function notifyDiscord(webhookUrl, articles, webhookType, feedType) {
                     title: article.title,
                     description: article.contentSnippet,
                     url: article.url,
-                    timestamp: article.date_published.toFormat('yyyy-MM-dd\'T\'HH:mm:ssZZ'),
+                    timestamp: DateTime.fromISO(article.date_published, { zone: 'utc' }).setZone(timezone).toISO(),
                 }]
             });
         });
@@ -169,7 +169,7 @@ async function processImage(imageUrl, imageName) {
 }
 
 async function processFeeds(feeds, concurrencyLimit = 5) {
-  const errors = new Set();
+  const errors = createErrorArray();
   const results = [];
 
   for (let i = 0; i < feeds.length; i += concurrencyLimit) {
@@ -177,7 +177,7 @@ async function processFeeds(feeds, concurrencyLimit = 5) {
     const feedPromises = feedBatch.map(feed => processFeed(feed, errors));
     const batchResults = await Promise.allSettled(feedPromises);
 
-    batchResults.filter(result => result.status === 'rejected').forEach(result => errors.add(result.reason));
+    batchResults.filter(result => result.status === 'rejected').forEach(result => errors.addError(result.reason));
     results.push(...batchResults.filter(result => result.status === 'fulfilled').map(result => result.value));
   }
 
@@ -186,7 +186,8 @@ async function processFeeds(feeds, concurrencyLimit = 5) {
 
 async function processFeed(feed, errors) {
     try {
-        const lastRetrieved = DateTime.fromISO(feed.last_retrieved, { zone: 'utc' }).setZone(timezone) || DateTime.fromISO('1970-01-01T00:00:00Z', { zone: 'utc' }).setZone(timezone);
+        const parsed = DateTime.fromISO(feed.last_retrieved, { zone: 'utc' }).setZone(timezone);
+        const lastRetrieved = parsed.isValid ? parsed : DateTime.fromISO('1970-01-01T00:00:00Z', { zone: 'utc' }).setZone(timezone);
         const newArticles = await checkForNewArticles(feed.url, lastRetrieved);
         if (newArticles.length === 0) return { feedId: feed.id, updates: [], notifications: [] };
         
@@ -278,7 +279,7 @@ async function main() {
             const latestUpdates = selectMap.map(update => {
                 const fullFeedData = feedMap.get(update.id);
                 if (fullFeedData) {
-                    return { ...fullFeedData, 'last_retrieved': currentDateTime };
+                    return { ...fullFeedData, 'last_retrieved': currentDateTime.toISO() };
                 } else {
                     console.error('Full feed data not found for update id:', update.id);
                 }

--- a/packages/sendPy/discord_http_client.py
+++ b/packages/sendPy/discord_http_client.py
@@ -1,0 +1,66 @@
+from copy import deepcopy
+from urllib.parse import urlparse
+
+import requests
+
+
+ALLOWED_DISCORD_HOST_SUFFIXES = ("discord.com", "discordapp.com")
+WEBHOOK_PATH_FRAGMENT = "/api/webhooks/"
+MAX_DISCORD_CONTENT_LEN = 2000
+
+
+def _is_allowed_discord_webhook_url(webhook_url: str) -> bool:
+    parsed = urlparse(webhook_url)
+    if parsed.scheme != "https":
+        return False
+
+    host = (parsed.hostname or "").lower()
+    if not any(host == suffix or host.endswith(f".{suffix}") for suffix in ALLOWED_DISCORD_HOST_SUFFIXES):
+        return False
+
+    return WEBHOOK_PATH_FRAGMENT in (parsed.path or "")
+
+
+def _normalize_payload(payload: dict) -> dict:
+    normalized = deepcopy(payload)
+
+    # 防御的にメンション抑止（必要時は明示指定で上書き可）
+    normalized.setdefault("allowed_mentions", {"parse": []})
+
+    content = normalized.get("content")
+    if isinstance(content, str):
+        normalized["content"] = content[:MAX_DISCORD_CONTENT_LEN]
+
+    return normalized
+
+
+def post_discord_or_throw(webhook_url: str, payload: dict, timeout: int = 10) -> None:
+    """Post payload to Discord webhook and raise on failures."""
+    if not webhook_url:
+        raise ValueError("Discord webhook URL is not configured.")
+    if not _is_allowed_discord_webhook_url(webhook_url):
+        raise ValueError("Webhook URL must be an https Discord webhook endpoint.")
+    if not isinstance(payload, dict):
+        raise ValueError("Payload must be a dictionary.")
+    if timeout <= 0:
+        raise ValueError("Timeout must be greater than 0.")
+
+    safe_payload = _normalize_payload(payload)
+
+    try:
+        response = requests.post(
+            webhook_url,
+            json=safe_payload,
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "cccDataImporter/sendPy-discord-client",
+            },
+            timeout=timeout,
+        )
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Failed to send message due to network error: {exc}") from exc
+
+    if response.status_code != 204:
+        raise RuntimeError(
+            f"Failed to send message: {response.status_code}, {response.text[:300]}"
+        )

--- a/packages/sendPy/send_beautiful_view.py
+++ b/packages/sendPy/send_beautiful_view.py
@@ -22,7 +22,7 @@ api_options = [
 
 def send_error_to_discord(error_message: str):
     error_data = {
-        "content": f"【Cat Channel】Error occurred: {error_message}"
+        "content": f"【Beautiful View Channel】Error occurred: {error_message}"
     }
     headers = {"Content-Type": "application/json"}
     response = requests.post(ERROR_WEBHOOK_URL, json=error_data, headers=headers)
@@ -63,27 +63,25 @@ def get_image_url(api_option):
         return None, str(error)
 
 def fetch_image_and_send_to_discord(api_options):
-    if not api_options:
-        send_error_to_discord("No API options available to fetch images.")
-        return
-
-    source = random.choice(api_options)
-    print(f"Fetching image from {source['name']}...")
-    image_url, footer_or_error = get_image_url(source)
-    if image_url:
-        embed = {
-            "image": {"url": image_url},
-            "footer": {"text": footer_or_error}
-        }
-        data = {"embeds": [embed]}
-        headers = {"Content-Type": "application/json"}
-        response = requests.post(BEAUTIFULVIEW_DISCORD_WEBHOOK_URL, json=data, headers=headers)
-        if response.status_code == 204:
-            print("Successfully sent message to Discord.")
-        else:
-            send_error_to_discord(f"Failed to send message: {response.status_code}, {response.text}")
-    else:
-        api_options.remove(source)
-        fetch_image_and_send_to_discord(api_options)
+    remaining = list(api_options)
+    while remaining:
+        source = random.choice(remaining)
+        print(f"Fetching image from {source['name']}...")
+        image_url, footer_or_error = get_image_url(source)
+        if image_url:
+            embed = {
+                "image": {"url": image_url},
+                "footer": {"text": footer_or_error}
+            }
+            data = {"embeds": [embed]}
+            headers = {"Content-Type": "application/json"}
+            response = requests.post(BEAUTIFULVIEW_DISCORD_WEBHOOK_URL, json=data, headers=headers)
+            if response.status_code == 204:
+                print("Successfully sent message to Discord.")
+            else:
+                send_error_to_discord(f"Failed to send message: {response.status_code}, {response.text}")
+            return
+        remaining.remove(source)
+    send_error_to_discord("No API options available to fetch images.")
 
 fetch_image_and_send_to_discord(api_options)

--- a/packages/sendPy/send_beautiful_view.py
+++ b/packages/sendPy/send_beautiful_view.py
@@ -65,7 +65,7 @@ def get_image_url(api_option):
 def fetch_image_and_send_to_discord(api_options):
     remaining = list(api_options)
     while remaining:
-        source = random.choice(remaining)
+        source = remaining.pop(random.randrange(len(remaining)))
         print(f"Fetching image from {source['name']}...")
         image_url, footer_or_error = get_image_url(source)
         if image_url:
@@ -81,7 +81,6 @@ def fetch_image_and_send_to_discord(api_options):
             else:
                 send_error_to_discord(f"Failed to send message: {response.status_code}, {response.text}")
             return
-        remaining.remove(source)
-    send_error_to_discord("No API options available to fetch images.")
+    send_error_to_discord("All API sources failed to fetch images.")
 
 fetch_image_and_send_to_discord(api_options)

--- a/packages/sendPy/send_cat_image.py
+++ b/packages/sendPy/send_cat_image.py
@@ -78,27 +78,25 @@ def get_image_url(api_option):
         return None, str(error)
 
 def fetch_image_and_send_to_discord(api_options):
-    if not api_options:
-        send_error_to_discord("No API options available to fetch images.")
-        return
-
-    source = random.choice(api_options)
-    print(f"Fetching image from {source['name']}...")
-    image_url, footer_or_error = get_image_url(source)
-    if image_url:
-        embed = {
-            "image": {"url": image_url},
-            "footer": {"text": footer_or_error}
-        }
-        data = {"embeds": [embed]}
-        headers = {"Content-Type": "application/json"}
-        response = requests.post(CAT_DISCORD_WEBHOOK_URL, json=data, headers=headers)
-        if response.status_code == 204:
-            print("Successfully sent message to Discord.")
-        else:
-            send_error_to_discord(f"Failed to send message: {response.status_code}, {response.text}")
-    else:
-        api_options.remove(source)
-        fetch_image_and_send_to_discord(api_options)
+    remaining = list(api_options)
+    while remaining:
+        source = random.choice(remaining)
+        print(f"Fetching image from {source['name']}...")
+        image_url, footer_or_error = get_image_url(source)
+        if image_url:
+            embed = {
+                "image": {"url": image_url},
+                "footer": {"text": footer_or_error}
+            }
+            data = {"embeds": [embed]}
+            headers = {"Content-Type": "application/json"}
+            response = requests.post(CAT_DISCORD_WEBHOOK_URL, json=data, headers=headers)
+            if response.status_code == 204:
+                print("Successfully sent message to Discord.")
+            else:
+                send_error_to_discord(f"Failed to send message: {response.status_code}, {response.text}")
+            return
+        remaining.remove(source)
+    send_error_to_discord("No API options available to fetch images.")
 
 fetch_image_and_send_to_discord(api_options)

--- a/packages/sendPy/send_cat_image.py
+++ b/packages/sendPy/send_cat_image.py
@@ -80,7 +80,7 @@ def get_image_url(api_option):
 def fetch_image_and_send_to_discord(api_options):
     remaining = list(api_options)
     while remaining:
-        source = random.choice(remaining)
+        source = remaining.pop(random.randrange(len(remaining)))
         print(f"Fetching image from {source['name']}...")
         image_url, footer_or_error = get_image_url(source)
         if image_url:
@@ -96,7 +96,6 @@ def fetch_image_and_send_to_discord(api_options):
             else:
                 send_error_to_discord(f"Failed to send message: {response.status_code}, {response.text}")
             return
-        remaining.remove(source)
-    send_error_to_discord("No API options available to fetch images.")
+    send_error_to_discord("All API sources failed to fetch images.")
 
 fetch_image_and_send_to_discord(api_options)

--- a/packages/sendPy/send_today_wiki.py
+++ b/packages/sendPy/send_today_wiki.py
@@ -42,7 +42,7 @@ def main():
         "description": content_snippet,
         "url": page.url,
         "color": 3447003,
-        "timestamp": today.isoformat(),
+        "timestamp": tomorrow.isoformat(),
         "footer": {
             "text": "Powered by Wikipedia"
         },

--- a/packages/sendPy/send_today_wiki.py
+++ b/packages/sendPy/send_today_wiki.py
@@ -1,61 +1,46 @@
-import wikipedia
-import requests
 import datetime
 import os
 import random
+import wikipedia
+
+from discord_http_client import post_discord_or_throw
+from wiki_page_resolver import resolve_page_with_disambiguation, SELECTION_FIRST
 
 # Discord Webhook URLs
 WIKI_DISCORD_WEBHOOK_URL = os.getenv('WIKI_DISCORD_WEBHOOK_URL')
 ERROR_WEBHOOK_URL = os.getenv('ERROR_WEBHOOK_URL')
 
+
 def send_error_to_discord(error_message: str):
     error_data = {
-        "content": f"【WIKI Channel】Error occurred: {error_message}"
+        "content": f"【WIKI Channel】Error occurred: {error_message[:1900]}"
     }
-    headers = {"Content-Type": "application/json"}
-    response = requests.post(ERROR_WEBHOOK_URL, json=error_data, headers=headers)
-    if response.status_code != 204:
-        print(f"Failed to send error message: {response.status_code}, {response.text}")
+    post_discord_or_throw(ERROR_WEBHOOK_URL, error_data)
 
-try:
-    # 日本語WikipediaのURLを設定
+
+def main():
     wikipedia.set_lang("ja")
 
-    # 当日の日付を取得
     today = datetime.datetime.now()
     month = today.strftime("%m")
     day = (today + datetime.timedelta(days=1)).strftime("%d")
 
-    # Wikipediaの「今日は何の日？」ページを取得
     page_title = f"{month}月{day}日"
-    page = wikipedia.page(page_title)
+    page = resolve_page_with_disambiguation(page_title, selection_rule=SELECTION_FIRST)
 
-    # 記事のセクションを取得
-    content = page.content
+    sections = [section for section in page.content.split("\n\n") if section.strip()]
+    if not sections:
+        raise RuntimeError(f"No sections found in page content: {page_title}")
 
-    # いくつかの分割方法がありますが、例として "\n\n" を使用
-    sections = content.split("\n\n")
-
-    # ランダムに記事を選択
     random_section = random.choice(sections)
+    content_snippet = random_section[:500]
+    image_url = page.images[0] if page.images else None
 
-    # 記事のタイトルと内容を取得
-    title = page_title
-    content_snippet = random_section[:500]  # 内容の一部を取得（長すぎる場合があるため）
-
-    # 記事のURLを取得
-    article_url = page.url
-
-    # 記事内の画像を取得
-    images = page.images
-    image_url = images[0] if images else None
-
-    # Embedメッセージの作成
     embed = {
-        "title": f"今日は何の日？: {title}",
+        "title": f"今日は何の日？: {page_title}",
         "description": content_snippet,
-        "url": article_url,
-        "color": 3447003,  # Blue
+        "url": page.url,
+        "color": 3447003,
         "timestamp": today.isoformat(),
         "footer": {
             "text": "Powered by Wikipedia"
@@ -65,20 +50,16 @@ try:
     if image_url:
         embed["thumbnail"] = {"url": image_url}
 
-    # Webhookデータの作成
-    data = {
-        "embeds": [embed]
-    }
+    data = {"embeds": [embed]}
+    post_discord_or_throw(WIKI_DISCORD_WEBHOOK_URL, data)
+    print("Successfully sent message to Discord.")
 
-    # Webhookに送信
-    headers = {"Content-Type": "application/json"}
-    response = requests.post(WIKI_DISCORD_WEBHOOK_URL, json=data, headers=headers)
 
-    if response.status_code == 204:
-        print("Successfully sent message to Discord.")
-    else:
-        raise Exception(f"Failed to send message: {response.status_code}, {response.text}")
-
-except Exception as error:
-    # エラー内容をエラーメッセージ用のDiscord Webhookに送信
-    send_error_to_discord(str(error))
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as error:
+        try:
+            send_error_to_discord(str(error))
+        except Exception as notify_error:
+            print(f"Failed to notify error webhook: {notify_error}")

--- a/packages/sendPy/send_today_wiki.py
+++ b/packages/sendPy/send_today_wiki.py
@@ -22,8 +22,9 @@ def main():
     wikipedia.set_lang("ja")
 
     today = datetime.datetime.now()
-    month = today.strftime("%m")
-    day = (today + datetime.timedelta(days=1)).strftime("%d")
+    tomorrow = today + datetime.timedelta(days=1)
+    month = tomorrow.strftime("%m")
+    day = tomorrow.strftime("%d")
 
     page_title = f"{month}月{day}日"
     page = resolve_page_with_disambiguation(page_title, selection_rule=SELECTION_FIRST)

--- a/packages/sendPy/send_wiki.py
+++ b/packages/sendPy/send_wiki.py
@@ -1,51 +1,43 @@
-import wikipedia
-import requests
 import os
+import wikipedia
+
+from discord_http_client import post_discord_or_throw
+from wiki_page_resolver import resolve_page_with_disambiguation, SELECTION_RANDOM
 
 # Discord Webhook URLs
 WIKI_DISCORD_WEBHOOK_URL = os.getenv('WIKI_DISCORD_WEBHOOK_URL')
 ERROR_WEBHOOK_URL = os.getenv('ERROR_WEBHOOK_URL')
 
+
 def send_error_to_discord(error_message: str):
     error_data = {
-        "content": f"【WIKI Channel】Error occurred: {error_message}"
+        "content": f"【WIKI Channel】Error occurred: {error_message[:1900]}"
     }
-    headers = {"Content-Type": "application/json"}
-    response = requests.post(ERROR_WEBHOOK_URL, json=error_data, headers=headers)
-    if response.status_code != 204:
-        print(f"Failed to send error message: {response.status_code}, {response.text}")
+    post_discord_or_throw(ERROR_WEBHOOK_URL, error_data)
 
-try:
-    # 日本語WikipediaのURLを設定
+
+def main():
     wikipedia.set_lang("ja")
 
-    # ランダムなページを取得
     random_page = wikipedia.random()
+    page = resolve_page_with_disambiguation(random_page, selection_rule=SELECTION_RANDOM)
 
-    # ページ情報を取得
-    page = wikipedia.page(random_page)
-    title = page.title
-    url = page.url
-    summary = page.summary
-    
-    # embed作成
     embed = {
-        "title": title,
-        "url": url,
-        "description": summary[:2048]  # Discordの制限で説明は2048文字まで
+        "title": page.title,
+        "url": page.url,
+        "description": page.summary[:2048],
     }
-    # Discord用のメッセージを準備
 
-    # Webhookを通じてDiscordにメッセージを送信
     data = {"embeds": [embed]}
-    headers = {"Content-Type": "application/json"}
-    response = requests.post(WIKI_DISCORD_WEBHOOK_URL, json=data, headers=headers)
+    post_discord_or_throw(WIKI_DISCORD_WEBHOOK_URL, data)
+    print("Successfully sent message to Discord.")
 
-    if response.status_code == 204:
-        print("Successfully sent message to Discord.")
-    else:
-        raise Exception(f"Failed to send message: {response.status_code}, {response.text}")
 
-except Exception as error:
-    # エラー内容をエラーメッセージ用のDiscord Webhookに送信
-    send_error_to_discord(str(error))
+if __name__ == '__main__':
+    try:
+        main()
+    except Exception as error:
+        try:
+            send_error_to_discord(str(error))
+        except Exception as notify_error:
+            print(f"Failed to notify error webhook: {notify_error}")

--- a/packages/sendPy/tests/test_wiki_disambiguation.py
+++ b/packages/sendPy/tests/test_wiki_disambiguation.py
@@ -1,0 +1,121 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+import wikipedia
+
+CURRENT_DIR = os.path.dirname(__file__)
+SEND_PY_DIR = os.path.abspath(os.path.join(CURRENT_DIR, ".."))
+if SEND_PY_DIR not in sys.path:
+    sys.path.insert(0, SEND_PY_DIR)
+
+from discord_http_client import post_discord_or_throw
+from wiki_page_resolver import resolve_page_with_disambiguation
+
+
+class TestWikiDisambiguation(unittest.TestCase):
+    @patch("wiki_page_resolver.print")
+    @patch("wiki_page_resolver.wikipedia.page")
+    @patch("wiki_page_resolver.wikipedia.search")
+    def test_disambiguation_retry_success(self, mock_search, mock_page, mock_print):
+        mock_page.side_effect = [
+            wikipedia.exceptions.DisambiguationError("曖昧語", []),
+            MagicMock(title="候補1"),
+        ]
+        mock_search.return_value = ["候補1", "候補2", "候補3", "候補4"]
+
+        result = resolve_page_with_disambiguation("曖昧語", selection_rule="first")
+
+        self.assertEqual(result.title, "候補1")
+        self.assertEqual(mock_page.call_count, 2)
+        mock_search.assert_called_once_with("曖昧語")
+        mock_page.assert_any_call("候補1")
+        mock_print.assert_any_call("Disambiguation candidates (top 3) for '曖昧語': ['候補1', '候補2', '候補3']")
+
+    @patch("wiki_page_resolver.wikipedia.page")
+    @patch("wiki_page_resolver.wikipedia.search")
+    def test_disambiguation_with_zero_candidates_raises(self, mock_search, mock_page):
+        mock_page.side_effect = wikipedia.exceptions.DisambiguationError("曖昧語", [])
+        mock_search.return_value = []
+
+        with self.assertRaises(RuntimeError) as ctx:
+            resolve_page_with_disambiguation("曖昧語", selection_rule="first")
+
+        self.assertIn("No disambiguation candidates", str(ctx.exception))
+
+    @patch("wiki_page_resolver.random.choice", return_value="候補2")
+    @patch("wiki_page_resolver.wikipedia.page")
+    @patch("wiki_page_resolver.wikipedia.search")
+    def test_disambiguation_random_selection(self, mock_search, mock_page, _mock_choice):
+        mock_page.side_effect = [
+            wikipedia.exceptions.DisambiguationError("曖昧語", []),
+            MagicMock(title="候補2"),
+        ]
+        mock_search.return_value = ["候補1", "候補2", "候補3"]
+
+        result = resolve_page_with_disambiguation("曖昧語", selection_rule="random")
+
+        self.assertEqual(result.title, "候補2")
+        mock_page.assert_any_call("候補2")
+
+    def test_disambiguation_invalid_rule_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            resolve_page_with_disambiguation("曖昧語", selection_rule="invalid")
+
+        self.assertIn("Unsupported selection_rule", str(ctx.exception))
+
+    def test_disambiguation_invalid_query_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            resolve_page_with_disambiguation("", selection_rule="first")
+
+        self.assertIn("non-empty string", str(ctx.exception))
+
+
+class TestDiscordWebhookClient(unittest.TestCase):
+    @patch("discord_http_client.requests.post")
+    def test_webhook_failure_raises(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=500, text="internal error")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            post_discord_or_throw("https://discord.com/api/webhooks/a/b", {"content": "hello"})
+
+        self.assertIn("Failed to send message", str(ctx.exception))
+
+    @patch("discord_http_client.requests.post")
+    def test_webhook_network_error_raises(self, mock_post):
+        mock_post.side_effect = requests.RequestException("timeout")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            post_discord_or_throw("https://discord.com/api/webhooks/a/b", {"content": "hello"})
+
+        self.assertIn("network error", str(ctx.exception))
+
+    def test_webhook_invalid_url_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            post_discord_or_throw("http://example.com/webhook", {"content": "hello"})
+
+        self.assertIn("Discord webhook endpoint", str(ctx.exception))
+
+    def test_webhook_invalid_timeout_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            post_discord_or_throw("https://discord.com/api/webhooks/a/b", {"content": "hello"}, timeout=0)
+
+        self.assertIn("greater than 0", str(ctx.exception))
+
+    @patch("discord_http_client.requests.post")
+    def test_webhook_payload_normalized(self, mock_post):
+        mock_post.return_value = MagicMock(status_code=204, text="")
+        content = "x" * 2100
+
+        post_discord_or_throw("https://discord.com/api/webhooks/a/b", {"content": content})
+
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], "https://discord.com/api/webhooks/a/b")
+        self.assertEqual(kwargs["json"]["allowed_mentions"], {"parse": []})
+        self.assertEqual(len(kwargs["json"]["content"]), 2000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/sendPy/wiki_page_resolver.py
+++ b/packages/sendPy/wiki_page_resolver.py
@@ -1,0 +1,57 @@
+import random
+import wikipedia
+
+
+SELECTION_FIRST = "first"
+SELECTION_RANDOM = "random"
+ALLOWED_SELECTION_RULES = (SELECTION_FIRST, SELECTION_RANDOM)
+MAX_DISAMBIGUATION_RETRIES = 2
+
+
+def _normalize_candidates(candidates):
+    normalized = []
+    seen = set()
+    for candidate in candidates:
+        title = (candidate or "").strip()
+        if not title or title in seen:
+            continue
+        seen.add(title)
+        normalized.append(title)
+    return normalized
+
+
+def _pick_title(candidates, selection_rule: str):
+    if selection_rule == SELECTION_RANDOM:
+        return random.choice(candidates)
+    return candidates[0]
+
+
+def resolve_page_with_disambiguation(query: str, selection_rule: str = SELECTION_FIRST):
+    """Resolve a Wikipedia page, retrying with search candidates on disambiguation."""
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError("Query must be a non-empty string.")
+    if selection_rule not in ALLOWED_SELECTION_RULES:
+        raise ValueError(
+            f"Unsupported selection_rule '{selection_rule}'. "
+            f"Allowed: {ALLOWED_SELECTION_RULES}"
+        )
+
+    current_query = query
+    for _ in range(MAX_DISAMBIGUATION_RETRIES + 1):
+        try:
+            return wikipedia.page(current_query)
+        except wikipedia.exceptions.DisambiguationError:
+            candidates = _normalize_candidates(wikipedia.search(current_query))
+            top3 = candidates[:3]
+            print(f"Disambiguation candidates (top 3) for '{current_query}': {top3}")
+
+            if not candidates:
+                raise RuntimeError(f"No disambiguation candidates found for query: {current_query}")
+
+            selected_title = _pick_title(candidates, selection_rule)
+            print(
+                f"Disambiguation resolved by '{selection_rule}' selection: {selected_title}"
+            )
+            current_query = selected_title
+
+    raise RuntimeError(f"Disambiguation retry limit exceeded for query: {query}")

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,7 +1762,16 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.13.2.tgz#0aa167216965ac9474ccfa83892cfb6b3e1e52ef"
   integrity sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==
 
-axios@^1.12.0, axios@^1.7.4:
+axios@^1.13.5:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.6.tgz#c3f92da917dc209a15dd29936d20d5089b6b6c98"
+  integrity sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==
+  dependencies:
+    follow-redirects "^1.15.11"
+    form-data "^4.0.5"
+    proxy-from-env "^1.1.0"
+
+axios@^1.7.4:
   version "1.13.5"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
   integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==


### PR DESCRIPTION
### Motivation
- Centralize and harden Discord webhook posting with input validation, payload normalization, and clearer error handling.
- Improve Wikipedia page resolution to handle disambiguation automatically and support deterministic or random candidate selection.
- Replace ad-hoc webhook calls in sender scripts with the new client and add safer error reporting and content truncation.

### Description
- Added `discord_http_client.py` with `post_discord_or_throw` which validates webhook URLs, normalizes payloads (suppresses mentions by default and truncates `content`), and raises detailed `RuntimeError` on network or HTTP failures.
- Added `wiki_page_resolver.py` which implements `resolve_page_with_disambiguation` to retry on `DisambiguationError`, normalize search candidates, and support `SELECTION_FIRST` and `SELECTION_RANDOM` rules.
- Refactored `send_wiki.py` and `send_today_wiki.py` to use `post_discord_or_throw` and `resolve_page_with_disambiguation`, tighten content length limits, and wrap execution in `main()` with guarded `__main__` error notification to the error webhook.
- Added unit tests `tests/test_wiki_disambiguation.py` that cover disambiguation behavior and `discord_http_client` error/normalization cases.

### Testing
- Ran unit tests in `packages/sendPy/tests` with `python -m unittest discover packages/sendPy/tests`, and all tests passed.
- Verified disambiguation logic and webhook client behavior via mocked tests in `tests/test_wiki_disambiguation.py`, which assert retry, selection rules, payload normalization, and error raising.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb5ee4d8048324a0416c3cd9882d62)