### PR TITLE
Add URL safety/sanitization, refactor HTTP calls, and improve error handling in aliceBlogChecker

### DIFF
--- a/packages/aliceBlogChecker/src/index.js
+++ b/packages/aliceBlogChecker/src/index.js
@@ -3,8 +3,9 @@ const feedparser = require('feedparser-promised');
 const htmlToText = require('html-to-text');
 const { JSDOM } = require('jsdom');
 const { DateTime } = require('luxon');
-const fs = require('fs');
 const path = require('path');
+const net = require('net');
+const { fetchWithRetry, postDiscordOrThrow } = require('../../common/httpClient.cjs');
 
 if (!process.env.GITHUB_ACTIONS) {
   require('dotenv').config({ path: path.resolve(__dirname, '../../../.env') });
@@ -17,66 +18,128 @@ const SUPABASE_FEED_TABLE_NAME = process.env.SUPABASE_FEED_TABLE_NAME;
 const SUPABASE_FEED_TYPE_ALICE = process.env.SUPABASE_FEED_TYPE_ALICE;
 
 if (!SUPABASE_URL || !SUPABASE_KEY || !ALICE_DISCORD_WEBHOOK_URL || !SUPABASE_FEED_TABLE_NAME || !SUPABASE_FEED_TYPE_ALICE) {
-  throw new Error("Missing required environment variables.");
+  throw new Error('Missing required environment variables.');
 }
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
-
 const timezone = 'Asia/Tokyo';
+const DISCORD_MAX_CONTENT_LENGTH = 1900;
+
+function toErrorMessage(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch (_) {
+    return String(error);
+  }
+}
+
+function sanitizeText(text) {
+  if (typeof text !== 'string') {
+    return text;
+  }
+
+  return text
+    .replace(/https?:\/\/[^\s)]+/g, (value) => {
+      try {
+        const parsed = new URL(value);
+        return `[REDACTED URL:${parsed.hostname}]`;
+      } catch (_) {
+        return '[REDACTED URL]';
+      }
+    })
+    .replace(/\b\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\b/g, '[REDACTED ID]');
+}
+
+function isPrivateOrLocalAddress(hostname) {
+  const normalized = (hostname || '').toLowerCase();
+  if (!normalized) return true;
+  if (normalized === 'localhost' || normalized.endsWith('.local')) return true;
+
+  const ipType = net.isIP(normalized);
+  if (ipType === 4) {
+    if (normalized.startsWith('10.') || normalized.startsWith('127.') || normalized.startsWith('192.168.')) return true;
+    const secondOctet = Number(normalized.split('.')[1]);
+    if (normalized.startsWith('172.') && secondOctet >= 16 && secondOctet <= 31) return true;
+  }
+  if (ipType === 6) {
+    if (normalized === '::1' || normalized.startsWith('fc') || normalized.startsWith('fd')) return true;
+  }
+  return false;
+}
+
+function assertSafeUrl(rawUrl, { httpsOnly = false, label }) {
+  try {
+    const parsed = new URL(rawUrl);
+    const allowedProtocol = httpsOnly ? parsed.protocol === 'https:' : parsed.protocol === 'https:' || parsed.protocol === 'http:';
+    if (!allowedProtocol) {
+      throw new Error(`Unsupported protocol for ${label}`);
+    }
+    if (isPrivateOrLocalAddress(parsed.hostname)) {
+      throw new Error(`Blocked private/local host for ${label}`);
+    }
+    return parsed;
+  } catch (error) {
+    throw new Error(`Unsafe URL for ${label}: ${sanitizeText(rawUrl)} (${toErrorMessage(error)})`);
+  }
+}
+
+function parseFeedDate(dateString) {
+  if (!dateString) {
+    return null;
+  }
+
+  const parsers = [DateTime.fromRFC2822, DateTime.fromISO, DateTime.fromHTTP];
+  for (const parser of parsers) {
+    const parsed = parser(dateString, { zone: timezone });
+    if (parsed.isValid) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
 
 async function handleError(error) {
   const ERROR_WEBHOOK_URL = process.env.ERROR_WEBHOOK_URL;
-  const GH_TOKEN = process.env.GH_TOKEN;
-  const GITHUB_REPO = process.env.GITHUB_REPO;
 
-  // エラーがオブジェクトの場合、messageとstackを取り出す
   if (error instanceof Error) {
     error = {
       message: error.message,
       stack: error.stack
     };
   }
-  // エラーが文字列の場合、オブジェクトに変換する
   if (typeof error === 'string') {
     error = {
       message: error
     };
   }
 
-  // messageとstackが文字列かどうかチェックする
-  if (typeof error.message === 'string') {
-    error.message = error.message.replace(/https?:\/\/\S+/g, '[REDACTED URL]').replace(/\b\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\b/g, '[REDACTED ID]');
-  }
-
-  if (typeof error.stack === 'string') {
-    error.stack = error.stack.replace(/https?:\/\/\S+/g, '[REDACTED URL]').replace(/\b\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\b/g, '[REDACTED ID]');
-  }
+  error.message = sanitizeText(error.message);
+  error.stack = sanitizeText(error.stack);
 
   console.log('Error:', error.message);
 
-  await fetch(ERROR_WEBHOOK_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ content: `【Alice Blog Check】Error: ${error.message}` })
-  });
-  // const sanitizedError = {
-  //     message: error.message.replace(/https?:\/\/\S+/g, '[REDACTED URL]').replace(/\b\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\b/g, '[REDACTED ID]'),
-  //     stack: error.stack ? error.stack.replace(/https?:\/\/\S+/g, '[REDACTED URL]').replace(/\b\w{8}-\w{4}-\w{4}-\w{4}-\w{12}\b/g, '[REDACTED ID]') : 'No stack trace available'
-  // };
-  // await fetch(
-  //     `https://api.github.com/repos/${GITHUB_REPO}/issues`,
-  //     {
-  //         method: 'POST',
-  //         headers: {
-  //             'Content-Type': 'application/json',
-  //             'Authorization': `token ${GH_TOKEN}`
-  //         },
-  //         body: JSON.stringify({
-  //             title: `ALICE Channel Error: ${sanitizedError.message}`,
-  //             body: sanitizedError.stack,
-  //         })
-  //     }
-  // );
+  if (!ERROR_WEBHOOK_URL) {
+    return;
+  }
+  assertSafeUrl(ERROR_WEBHOOK_URL, { httpsOnly: true, label: 'error webhook' });
+
+  const content = `【Alice Blog Check】Error: ${error.message}`.slice(0, DISCORD_MAX_CONTENT_LENGTH);
+  try {
+    await postDiscordOrThrow({
+      webhookUrl: ERROR_WEBHOOK_URL,
+      payload: { content },
+      jobName: 'aliceBlogChecker:handleError'
+    });
+  } catch (notifyError) {
+    console.error('Failed to send error webhook:', toErrorMessage(notifyError));
+  }
 }
 
 const fetchFeeds = async () => {
@@ -97,50 +160,42 @@ const checkAndUpdateFeeds = async (feeds) => {
   let updatesFound = false;
 
   try {
-    const accessToken = await authenticateUser();
+    await authenticateUser();
     for (const feed of feeds) {
-      const parsedFeed = await feedparser.parse({ uri: feed.url });
-      // 日付文字列の値をログに出力する
-      const pubdateString = parsedFeed[0].pubdate;
-      
-      // 日付文字列を解析して適切なDateTimeオブジェクトを作成する関数
-      const parseDate = (dateString) => {
-        let dateTime;
-        try {
-          dateTime = DateTime.fromRFC2822(dateString).setZone(timezone);
-        } catch (e) {
-          try {
-            dateTime = DateTime.fromISO(dateString).setZone(timezone);
-          } catch (e) {
-            handleError('Invalid date format:' + e.message);
-            return null;
-          }
+      try {
+        assertSafeUrl(feed.url, { httpsOnly: false, label: 'feed url' });
+        const parsedFeed = await feedparser.parse({ uri: feed.url });
+        if (!parsedFeed.length) {
+          throw new Error(`Feed has no entries. url=${feed.url}`);
         }
-        return dateTime;
-      };
-      const latestPubdate = parseDate(pubdateString);
-      if (!latestPubdate) {
-        throw new Error(`Invalid date format: ${pubdateString}`);
-      }
-      const lastRetrieved = feed.last_retrieved ? DateTime.fromISO(feed.last_retrieved).setZone(timezone) : null;
-      if (!lastRetrieved || latestPubdate > lastRetrieved) {
-        const latestPubdateUtc = latestPubdate.setZone('UTC').toISO();
-        const { data, error } = await supabase
-          .from(SUPABASE_FEED_TABLE_NAME)
-          .upsert({
-            id: feed.id,
-            feed_type: feed.feed_type,
-            name: feed.name,
-            url: feed.url,
-            webhook: feed.webhook,
-            hook_type: feed.hook_type,
-            notes: feed.notes,
-            last_retrieved: latestPubdateUtc
-          }, { onConflict: 'id' });
 
-        if (error) throw error;
-        updatesFound = true;
-        await postToDiscord(feed, parsedFeed, lastRetrieved);
+        const latestPubdate = parseFeedDate(parsedFeed[0].pubdate);
+        if (!latestPubdate) {
+          throw new Error(`Invalid date format: ${parsedFeed[0].pubdate}. url=${feed.url}`);
+        }
+
+        const lastRetrieved = feed.last_retrieved ? DateTime.fromISO(feed.last_retrieved).setZone(timezone) : null;
+        if (!lastRetrieved || latestPubdate > lastRetrieved) {
+          const latestPubdateUtc = latestPubdate.setZone('UTC').toISO();
+          const { error } = await supabase
+            .from(SUPABASE_FEED_TABLE_NAME)
+            .upsert({
+              id: feed.id,
+              feed_type: feed.feed_type,
+              name: feed.name,
+              url: feed.url,
+              webhook: feed.webhook,
+              hook_type: feed.hook_type,
+              notes: feed.notes,
+              last_retrieved: latestPubdateUtc
+            }, { onConflict: 'id' });
+
+          if (error) throw error;
+          updatesFound = true;
+          await postToDiscord(feed, parsedFeed, lastRetrieved);
+        }
+      } catch (error) {
+        await handleError(`Feed processing failed for url=${feed.url}: ${toErrorMessage(error)}`);
       }
     }
 
@@ -153,11 +208,12 @@ const checkAndUpdateFeeds = async (feeds) => {
 };
 
 const convertHtmlToMarkdown = (htmlContent) => {
-  return htmlToText.fromString(htmlContent, {
+  return htmlToText.convert(htmlContent || '', {
     wordwrap: 130,
     linkHrefBaseUrl: ''
   });
 };
+
 const authenticateUser = async () => {
   try {
     const { data, error } = await supabase.auth.signInWithPassword({
@@ -171,36 +227,44 @@ const authenticateUser = async () => {
     throw error;
   }
 };
+
 const postToDiscord = async (feed, entries, lastRetrieved = null) => {
-  entries.reverse();
-  
-  for (const entry of entries) {
-    const pubdate = DateTime.fromRFC2822(entry.pubdate).setZone(timezone);
-    
+  if (!feed.webhook) {
+    await handleError(`Missing webhook for feed url=${feed.url}`);
+    return;
+  }
+  assertSafeUrl(feed.webhook, { httpsOnly: true, label: `feed webhook url=${feed.url}` });
+
+  const orderedEntries = [...entries].reverse();
+
+  for (const entry of orderedEntries) {
+    const pubdate = parseFeedDate(entry.pubdate);
+    if (!pubdate) {
+      await handleError(`Skip entry with invalid date. url=${feed.url}`);
+      continue;
+    }
+
     if (lastRetrieved && pubdate <= lastRetrieved) continue;
 
-    const value = entry.description;
-    const dom = new JSDOM(value);
+    const description = entry.description || '';
+    const dom = new JSDOM(description);
     const imageElement = dom.window.document.querySelector('img');
     const imageUrl = imageElement ? imageElement.src : null;
 
     const embed = {
       title: entry.title,
-      description: convertHtmlToMarkdown(entry.description),
+      description: convertHtmlToMarkdown(description),
       url: entry.link,
       footer: { text: feed.name },
       image: { url: imageUrl }
     };
-    try {
-      const response = await fetch(feed.webhook, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ embeds: [embed] })
-      });
 
-      if (!response.ok) {
-        throw new Error(`Failed to send message: ${response.status}`);
-      }
+    try {
+      await postDiscordOrThrow({
+        webhookUrl: feed.webhook,
+        payload: { embeds: [embed] },
+        jobName: 'aliceBlogChecker:postToDiscord'
+      });
     } catch (error) {
       await handleError(error);
     }
@@ -210,7 +274,7 @@ const postToDiscord = async (feed, entries, lastRetrieved = null) => {
 const postRandomImageToDiscord = async (webhook) => {
   const PIXABAY_API_KEY = process.env.PIXABAY_API_KEY;
   const FLICKR_API_KEY = process.env.FLICKR_API_KEY;
-  
+
   const sources = [
     {
       url: (keyword) => {
@@ -240,14 +304,15 @@ const postRandomImageToDiscord = async (webhook) => {
     }
   ];
 
-  // どちらを使うかランダムに選択
   const source = sources[Math.floor(Math.random() * sources.length)];
 
   try {
-    const response = await fetch(source.url('alice in wonderland'));
-    if (!response.ok) {
-      throw new Error(`Failed to fetch image: ${response.statusText}`);
-    }
+    assertSafeUrl(webhook, { httpsOnly: true, label: 'main webhook' });
+    const response = await fetchWithRetry(
+      source.url('alice in wonderland'),
+      {},
+      { jobName: 'aliceBlogChecker:postRandomImageToDiscord' }
+    );
     const data = await response.json();
     const imageUrl = source.parseResponse(data);
     const embed = {
@@ -255,21 +320,29 @@ const postRandomImageToDiscord = async (webhook) => {
       footer: { text: source.footer }
     };
 
-    const discordResponse = await fetch(webhook, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ embeds: [embed] })
+    await postDiscordOrThrow({
+      webhookUrl: webhook,
+      payload: { embeds: [embed] },
+      jobName: 'aliceBlogChecker:postRandomImageToDiscord'
     });
-
-    if (!discordResponse.ok) {
-      throw new Error(`Failed to send message: ${discordResponse.status}`);
-    }
   } catch (error) {
-    handleError(error);
+    await handleError(error);
   }
 };
 
-(async () => {
-  const feeds = await fetchFeeds();
-  await checkAndUpdateFeeds(feeds);
-})();
+module.exports = {
+  parseFeedDate,
+  handleError,
+  fetchFeeds,
+  checkAndUpdateFeeds,
+  authenticateUser,
+  postToDiscord,
+  postRandomImageToDiscord
+};
+
+if (require.main === module) {
+  (async () => {
+    const feeds = await fetchFeeds();
+    await checkAndUpdateFeeds(feeds);
+  })();
+}

--- a/packages/aliceBlogChecker/tests/index.test.js
+++ b/packages/aliceBlogChecker/tests/index.test.js
@@ -1,91 +1,157 @@
-const { fetchFeeds } = require('../src/index');
-const { createClient } = require('@supabase/supabase-js');
-const { authenticateUser } = require('../src/index');
-const supabase = require('@supabase/supabase-js');
-const { handleError } = require('../src/index');
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_KEY = 'test-key';
+process.env.ALICE_DISCORD_WEBHOOK_URL = 'https://discord.com/api/webhooks/main';
+process.env.SUPABASE_FEED_TABLE_NAME = 'feeds';
+process.env.SUPABASE_FEED_TYPE_ALICE = 'alice';
+process.env.SUPABASE_EMAIL = 'alice@example.com';
+process.env.SUPABASE_PASSWORD = 'password';
+process.env.ERROR_WEBHOOK_URL = 'https://discord.com/api/webhooks/error';
 
-const TEST_FEED_URL = process.env.TEST_FEED;
+const mockParse = jest.fn();
+const mockUpsert = jest.fn();
+const mockEq = jest.fn();
+const mockSelect = jest.fn();
+const mockFrom = jest.fn();
+const mockSignInWithPassword = jest.fn();
 
-jest.mock('@supabase/supabase-js', () => {
-  return {
-    createClient: jest.fn(() => ({
-      from: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      then: jest.fn((callback) => {
-        return callback({ data: [{ id: 1, url: TEST_FEED_URL }], error: null });
-      }),
-    })),
-  };
-});
-
-jest.mock('../src/index', () => ({
-  ...jest.requireActual('../src/index'),
-  handleError: jest.fn(),
+jest.mock('feedparser-promised', () => ({
+  parse: (...args) => mockParse(...args)
 }));
 
-describe('fetchFeeds', () => {
-  it('should fetch feeds from supabase', async () => {
-    const feeds = await fetchFeeds();
-    expect(feeds).toEqual([{ id: 1, url: TEST_FEED_URL }]);
-  });
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: (...args) => mockFrom(...args),
+    auth: {
+      signInWithPassword: (...args) => mockSignInWithPassword(...args)
+    }
+  }))
+}));
 
-  it('should handle errors', async () => {
-    createClient.mockImplementationOnce(() => ({
-      from: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      then: jest.fn((callback, errCallback) => {
-        return errCallback(new Error('Supabase error'));
-      }),
-    }));
+const mockFetchWithRetry = jest.fn();
+const mockPostDiscordOrThrow = jest.fn();
+jest.mock('../../common/httpClient.cjs', () => ({
+  fetchWithRetry: (...args) => mockFetchWithRetry(...args),
+  postDiscordOrThrow: (...args) => mockPostDiscordOrThrow(...args)
+}));
 
-    const feeds = await fetchFeeds();
-    expect(feeds).toEqual([]);
-  });
+mockFrom.mockImplementation(() => ({
+  select: (...args) => mockSelect(...args),
+  upsert: (...args) => mockUpsert(...args)
+}));
 
-  it('should call handleError when there is an error', async () => {
-    createClient.mockImplementationOnce(() => ({
-      from: jest.fn().mockReturnThis(),
-      select: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockReturnThis(),
-      then: jest.fn((callback, errCallback) => {
-        return errCallback(new Error('Supabase error'));
-      }),
-    }));
+mockSelect.mockImplementation(() => ({
+  eq: (...args) => mockEq(...args)
+}));
 
-    await fetchFeeds();
-    expect(handleError).toHaveBeenCalledWith(new Error('Supabase error'));
-  });
+mockEq.mockResolvedValue({ data: [], error: null });
+mockUpsert.mockResolvedValue({ data: {}, error: null });
+mockSignInWithPassword.mockResolvedValue({
+  data: { session: { access_token: 'token' } },
+  error: null
 });
-describe('authenticateUser', () => {
-  it('should authenticate the user and return the access token', async () => {
-    const signInWithPasswordMock = jest.spyOn(supabase.auth, 'signInWithPassword').mockResolvedValue({
-      data: {
-        session: {
-          access_token: 'ACCESS_TOKEN'
-        }
-      },
+
+const aliceBlogChecker = require('../src/index');
+
+describe('aliceBlogChecker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+
+    mockEq.mockResolvedValue({ data: [], error: null });
+    mockUpsert.mockResolvedValue({ data: {}, error: null });
+    mockSignInWithPassword.mockResolvedValue({
+      data: { session: { access_token: 'token' } },
       error: null
     });
-
-    const accessToken = await authenticateUser();
-
-    expect(signInWithPasswordMock).toHaveBeenCalledWith({
-      email: SUPABASE_EMAIL,
-      password: SUPABASE_PASSWORD
-    });
-    expect(accessToken).toBe('ACCESS_TOKEN');
   });
 
-  it('should handle authentication error and throw an error', async () => {
-    const signInWithPasswordMock = jest.spyOn(supabase.auth, 'signInWithPassword').mockRejectedValue(new Error('Authentication error'));
+  it('parseFeedDate supports RFC2822 and ISO', () => {
+    const rfc = aliceBlogChecker.parseFeedDate('Wed, 02 Oct 2002 13:00:00 GMT');
+    const iso = aliceBlogChecker.parseFeedDate('2002-10-02T13:00:00.000Z');
+    const invalid = aliceBlogChecker.parseFeedDate('not-a-date');
 
-    await expect(authenticateUser()).rejects.toThrowError('Authentication error');
+    expect(rfc).not.toBeNull();
+    expect(iso).not.toBeNull();
+    expect(invalid).toBeNull();
+  });
 
-    expect(signInWithPasswordMock).toHaveBeenCalledWith({
-      email: SUPABASE_EMAIL,
-      password: SUPABASE_PASSWORD
+  it('does not call fetch directly and uses httpClient helpers', async () => {
+    mockFetchWithRetry.mockResolvedValue({
+      json: async () => ({ hits: [{ webformatURL: 'https://img.example/test.jpg' }] })
     });
+
+    await aliceBlogChecker.postRandomImageToDiscord('https://discord.com/api/webhooks/target');
+
+    expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
+    expect(mockPostDiscordOrThrow).toHaveBeenCalledTimes(1);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('continues processing when one feed fails', async () => {
+    const feeds = [
+      { id: 1, url: 'https://bad.example/rss', webhook: 'https://discord.com/api/webhooks/1', name: 'bad', feed_type: 'alice' },
+      { id: 2, url: 'https://good.example/rss', webhook: 'https://discord.com/api/webhooks/2', name: 'good', feed_type: 'alice' }
+    ];
+
+    mockParse
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce([
+        {
+          pubdate: 'Wed, 02 Oct 2002 13:00:00 GMT',
+          title: 'entry',
+          description: '<p>desc</p>',
+          link: 'https://good.example/entry'
+        }
+      ]);
+
+    await aliceBlogChecker.checkAndUpdateFeeds(feeds);
+
+    expect(mockParse).toHaveBeenCalledTimes(2);
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('continues when first feed URL is unsafe', async () => {
+    const feeds = [
+      { id: 1, url: 'http://localhost/internal', webhook: 'https://discord.com/api/webhooks/1', name: 'bad', feed_type: 'alice' },
+      { id: 2, url: 'https://good.example/rss', webhook: 'https://discord.com/api/webhooks/2', name: 'good', feed_type: 'alice' }
+    ];
+
+    mockParse.mockResolvedValue([
+      {
+        pubdate: 'Wed, 02 Oct 2002 13:00:00 GMT',
+        title: 'entry',
+        description: '<p>desc</p>',
+        link: 'https://good.example/entry'
+      }
+    ]);
+
+    await aliceBlogChecker.checkAndUpdateFeeds(feeds);
+
+    expect(mockParse).toHaveBeenCalledTimes(1);
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(mockPostDiscordOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          content: expect.stringContaining('Unsafe URL for feed url')
+        })
+      })
+    );
+  });
+
+  it('includes feed URL in error webhook message', async () => {
+    mockParse.mockRejectedValue(new Error('feed parse failure'));
+
+    await aliceBlogChecker.checkAndUpdateFeeds([
+      { id: 1, url: 'https://broken.example/rss', webhook: 'https://discord.com/api/webhooks/1', name: 'broken', feed_type: 'alice' }
+    ]);
+
+    expect(mockPostDiscordOrThrow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhookUrl: process.env.ERROR_WEBHOOK_URL,
+        payload: expect.objectContaining({
+          content: expect.stringContaining('url=[REDACTED URL:broken.example]')
+        })
+      })
+    );
   });
 });

--- a/packages/common/httpClient.cjs
+++ b/packages/common/httpClient.cjs
@@ -1,0 +1,23 @@
+let modulePromise;
+
+function loadHttpClientModule() {
+  if (!modulePromise) {
+    modulePromise = import('./httpClient.js');
+  }
+  return modulePromise;
+}
+
+async function fetchWithRetry(url, options = {}, config = {}) {
+  const module = await loadHttpClientModule();
+  return module.fetchWithRetry(url, options, config);
+}
+
+async function postDiscordOrThrow(params) {
+  const module = await loadHttpClientModule();
+  return module.postDiscordOrThrow(params);
+}
+
+module.exports = {
+  fetchWithRetry,
+  postDiscordOrThrow
+};


### PR DESCRIPTION
### Motivation
- Harden feed processing by preventing SSRF/private-host requests and removing raw `fetch` usage for Discord and external APIs. 
- Improve error sanitization so sensitive data (URLs, UUIDs) are redacted from logs and notifications. 
- Make the module testable and reusable by exporting main functions and moving HTTP helpers into a shared wrapper. 

### Description
- Added URL safety checks and sanitization utilities: `sanitizeText`, `toErrorMessage`, `isPrivateOrLocalAddress`, and `assertSafeUrl`, and new constant `DISCORD_MAX_CONTENT_LENGTH`.
- Replaced raw `fetch` calls with shared helpers `fetchWithRetry` and `postDiscordOrThrow` imported via a new `packages/common/httpClient.cjs` lazy wrapper, and added safe posting in `handleError`, `postToDiscord`, and `postRandomImageToDiscord`.
- Improved date parsing with a reusable `parseFeedDate` function using `luxon` and centralized feed-processing error handling; removed fragile inline date parsing logic.
- Added `net` import to detect IP addresses, removed unused `fs`, adjusted HTML-to-text call to `htmlToText.convert`, and made `aliceBlogChecker` export its functions with a `require.main === module` guard for CLI invocation.
- Strengthened feed processing: validate feed and webhook URLs with `assertSafeUrl`, skip invalid/unsafe entries, and ensure feeds with no entries raise handled errors.

### Testing
- Unit tests updated and run with `jest` covering `parseFeedDate`, use of http client helpers, resilient feed processing when one feed fails, handling of unsafe feed URLs, and error webhook content including redacted feed URL; all tests passed.
- Tests mock `feedparser-promised`, Supabase client, and `../../common/httpClient.cjs` helpers to assert behavior without real network requests, and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb5ee494c883248121af1ae9e36ae2)