### PR TITLE
Harden getPopularProducts: payload validation, error sanitization, safe images, and tests

### DIFF
--- a/packages/getPopularProducts/index.js
+++ b/packages/getPopularProducts/index.js
@@ -7,6 +7,9 @@ import { fetchWithRetry, postDiscordOrThrow } from '../common/httpClient.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const MAX_ERROR_MESSAGE_LENGTH = 1000;
+const MAX_ERROR_WEBHOOK_CONTENT_LENGTH = 1800;
+const ALLOWED_IMAGE_PROTOCOLS = new Set(['http:', 'https:']);
 
 if (!process.env.GITHUB_ACTIONS) {
   dotenv.config({ path: path.resolve(__dirname, '../../.env') });
@@ -25,6 +28,13 @@ if (!SUPABASE_URL || !SUPABASE_KEY || !SUPABASE_DAILY_TABLE_NAME || !ERROR_WEBHO
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
+export class BusinessValidationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'BusinessValidationError';
+  }
+}
+
 function createErrorArray() {
   let errorArray = [];
 
@@ -32,6 +42,34 @@ function createErrorArray() {
     addError: (error) => errorArray.push(error),
     getErrors: () => errorArray
   };
+}
+
+function sanitizeErrorMessage(message) {
+  return (message || 'Unknown error')
+    .replace(/(https?:\/\/[^\s]*?(?:token|key|secret|webhook)[^\s]*)/ig, '[REDACTED_URL]')
+    .replace(/[\r\n\t]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_ERROR_MESSAGE_LENGTH);
+}
+
+function toSafeContentHtml(value) {
+  return typeof value === 'string' ? value : '';
+}
+
+function isSafeImageUrl(urlString) {
+  try {
+    const parsed = new URL(urlString);
+    return ALLOWED_IMAGE_PROTOCOLS.has(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function truncateForDiscord(content) {
+  return content.length > MAX_ERROR_WEBHOOK_CONTENT_LENGTH
+    ? `${content.slice(0, MAX_ERROR_WEBHOOK_CONTENT_LENGTH - 3)}...`
+    : content;
 }
 
 async function getDiscordThreadId() {
@@ -43,31 +81,72 @@ async function getDiscordThreadId() {
     throw error;
   }
 
-  return data[0].forum_id;
+  const forumId = data?.[0]?.forum_id;
+  if (!forumId || typeof forumId !== 'string' || forumId.trim().length === 0) {
+    throw new BusinessValidationError('Invalid forum_id: missing Discord thread id.');
+  }
+
+  return forumId;
 }
 
-async function fetchProductHuntData() {
-  const response = await fetchWithRetry(PRODUCTHUNT_FEED_URL, {}, { jobName: 'getPopularProducts:fetchProductHuntData' });
-  const data = await response.json();
+function validateItemShape(item, index) {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) {
+    throw new BusinessValidationError(`Invalid Product Hunt response: item at index ${index} must be an object.`);
+  }
+
+  if (typeof item.title !== 'string' || item.title.trim().length === 0) {
+    throw new BusinessValidationError(`Invalid Product Hunt response: item at index ${index} has invalid title.`);
+  }
+
+  if (typeof item.url !== 'string' || item.url.trim().length === 0) {
+    throw new BusinessValidationError(`Invalid Product Hunt response: item at index ${index} has invalid url.`);
+  }
+}
+
+export function validateProductHuntPayload(data) {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new BusinessValidationError('Invalid Product Hunt response: root data must be an object.');
+  }
+
+  if (!Array.isArray(data.items)) {
+    throw new BusinessValidationError('Invalid Product Hunt response: data.items must be an array.');
+  }
+
+  if (data.items.length === 0) {
+    throw new BusinessValidationError('Invalid Product Hunt response: data.items must not be empty.');
+  }
+
+  data.items.forEach(validateItemShape);
+
   return data.items;
 }
 
+export async function fetchProductHuntData() {
+  const response = await fetchWithRetry(PRODUCTHUNT_FEED_URL, {}, { jobName: 'getPopularProducts:fetchProductHuntData' });
+  const data = await response.json();
+  return validateProductHuntPayload(data);
+}
+
 function extractImages(contentHtml) {
-  const imgUrls = [...contentHtml.matchAll(/<img src="([^"]+)"/g)].map((match) => decode(match[1]));
+  const imgUrls = [...toSafeContentHtml(contentHtml).matchAll(/<img src="([^"]+)"/g)]
+    .map((match) => decode(match[1]))
+    .filter(isSafeImageUrl);
+
   return imgUrls.length > 4 ? imgUrls.slice(0, 4) : imgUrls;
 }
 
 function formatDiscordMessages(posts) {
   return posts.slice(0, 10).map((post, index) => {
-    const description = post.content_html.split('<br>')[0];
-    const images = extractImages(post.content_html);
+    const safeContentHtml = toSafeContentHtml(post.content_html);
+    const description = safeContentHtml.split('<br>')[0];
+    const images = extractImages(safeContentHtml);
 
     const embeds = [{
       title: `${index + 1}. ${post.title}`,
       description,
       url: post.url,
       timestamp: post.date_published,
-      image: { url: images[0] }
+      ...(images[0] ? { image: { url: images[0] } } : {})
     }];
 
     images.slice(1).forEach((image) => {
@@ -78,9 +157,13 @@ function formatDiscordMessages(posts) {
   });
 }
 
-async function sendToDiscord(embeds) {
+export async function sendToDiscord(embeds) {
+  if (!Array.isArray(embeds)) {
+    throw new BusinessValidationError('Invalid embeds payload: expected array.');
+  }
+
   const forumId = await getDiscordThreadId();
-  const webhookUrl = `${DISCORD_DAILY_WEBHOOK_URL}?thread_id=${forumId}`;
+  const webhookUrl = `${DISCORD_DAILY_WEBHOOK_URL}?thread_id=${encodeURIComponent(forumId)}`;
 
   for (const embedSet of embeds) {
     const payload = { embeds: embedSet };
@@ -92,21 +175,24 @@ async function sendToDiscord(embeds) {
   }
 }
 
-async function handleError(errors) {
-  if (errors.length === 0) {
+export async function handleError(errors) {
+  if (!Array.isArray(errors) || errors.length === 0) {
     return;
   }
 
-  const errorMessage = errors.map((err) => err.message).join('\n');
+  const errorMessage = errors.map((err) => sanitizeErrorMessage(err?.message)).join(' | ');
+  const content = truncateForDiscord(`【Daily ProductHunt Top 10】Errors occurred: ${errorMessage}`);
+
   await postDiscordOrThrow({
     webhookUrl: ERROR_WEBHOOK_URL,
-    payload: { content: `【Daily ProductHunt Top 10】Errors occurred: ${errorMessage}` },
+    payload: { content },
     jobName: 'getPopularProducts:errorWebhook'
   });
 }
 
-async function main() {
+export async function main() {
   const errors = createErrorArray();
+  let caughtError;
 
   try {
     const posts = await fetchProductHuntData();
@@ -114,9 +200,27 @@ async function main() {
     await sendToDiscord(discordMessages);
   } catch (error) {
     errors.addError(error);
-  } finally {
+    caughtError = error;
+  }
+
+  try {
     await handleError(errors.getErrors());
+  } catch (notifyError) {
+    if (!caughtError) {
+      throw notifyError;
+    }
+
+    caughtError.cause = notifyError;
+  }
+
+  if (caughtError && !(caughtError instanceof BusinessValidationError)) {
+    throw caughtError;
   }
 }
 
-main();
+if (process.env.NODE_ENV !== 'test') {
+  main().catch((error) => {
+    console.error('[getPopularProducts] Fatal error', sanitizeErrorMessage(error?.message));
+    process.exitCode = 1;
+  });
+}

--- a/packages/getPopularProducts/tests/index.test.js
+++ b/packages/getPopularProducts/tests/index.test.js
@@ -1,0 +1,120 @@
+import { jest } from '@jest/globals';
+
+process.env.SUPABASE_URL = 'https://example.supabase.co';
+process.env.SUPABASE_KEY = 'test-key';
+process.env.SUPABASE_DAILY_TABLE_NAME = 'daily';
+process.env.ERROR_WEBHOOK_URL = 'https://discord.test/error';
+process.env.PRODUCTHUNT_FEED_URL = 'https://producthunt.test/feed';
+process.env.DISCORD_DAILY_WEBHOOK_URL = 'https://discord.test/daily';
+process.env.NODE_ENV = 'test';
+
+const fetchProductJsonMock = jest.fn();
+const fetchWithRetryMock = jest.fn();
+const postDiscordOrThrowMock = jest.fn();
+const selectMock = jest.fn().mockResolvedValue({ data: [{ forum_id: 'thread/123?x=1' }], error: null });
+const fromMock = jest.fn(() => ({ select: selectMock }));
+
+jest.unstable_mockModule('../../common/httpClient.js', () => ({
+  fetchWithRetry: fetchWithRetryMock,
+  postDiscordOrThrow: postDiscordOrThrowMock
+}));
+
+jest.unstable_mockModule('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: fromMock
+  }))
+}));
+
+const {
+  fetchProductHuntData,
+  sendToDiscord,
+  main,
+  handleError,
+  BusinessValidationError
+} = await import('../index.js');
+
+describe('getPopularProducts responsibility split', () => {
+  beforeEach(() => {
+    fetchProductJsonMock.mockReset();
+    fetchWithRetryMock.mockReset();
+    postDiscordOrThrowMock.mockReset();
+    selectMock.mockClear();
+    fromMock.mockClear();
+
+    fetchWithRetryMock.mockResolvedValue({ json: fetchProductJsonMock });
+  });
+
+  test('Round1: fetchProductHuntData delegates HTTP to fetchWithRetry and validates business payload', async () => {
+    fetchProductJsonMock.mockResolvedValue({
+      items: [{ id: 1, title: 'A', url: 'https://example.com/a' }]
+    });
+
+    await expect(fetchProductHuntData()).resolves.toEqual([{ id: 1, title: 'A', url: 'https://example.com/a' }]);
+
+    expect(fetchWithRetryMock).toHaveBeenCalledWith(
+      'https://producthunt.test/feed',
+      {},
+      { jobName: 'getPopularProducts:fetchProductHuntData' }
+    );
+  });
+
+  test('Round1: fetchProductHuntData throws BusinessValidationError on invalid payloads', async () => {
+    fetchProductJsonMock.mockResolvedValue(null);
+    await expect(fetchProductHuntData()).rejects.toBeInstanceOf(BusinessValidationError);
+
+    fetchProductJsonMock.mockResolvedValue({ items: 'invalid' });
+    await expect(fetchProductHuntData()).rejects.toBeInstanceOf(BusinessValidationError);
+
+    fetchProductJsonMock.mockResolvedValue({ items: [] });
+    await expect(fetchProductHuntData()).rejects.toBeInstanceOf(BusinessValidationError);
+
+    fetchProductJsonMock.mockResolvedValue({ items: [{ title: '', url: 'https://example.com' }] });
+    await expect(fetchProductHuntData()).rejects.toBeInstanceOf(BusinessValidationError);
+  });
+
+  test('Round2: sendToDiscord uses postDiscordOrThrow only and URL-encodes thread id', async () => {
+    postDiscordOrThrowMock.mockResolvedValue(undefined);
+
+    const embeds = [[{ title: '1. Product A' }], [{ title: '2. Product B' }]];
+    await sendToDiscord(embeds);
+
+    expect(postDiscordOrThrowMock).toHaveBeenCalledTimes(2);
+    expect(postDiscordOrThrowMock).toHaveBeenNthCalledWith(1, {
+      webhookUrl: 'https://discord.test/daily?thread_id=thread%2F123%3Fx%3D1',
+      payload: { embeds: embeds[0] },
+      jobName: 'getPopularProducts:postDiscordOrThrow'
+    });
+    expect(fetchWithRetryMock).not.toHaveBeenCalled();
+  });
+
+  test('Round2: sendToDiscord throws BusinessValidationError when forum_id or embeds is invalid', async () => {
+    await expect(sendToDiscord('invalid')).rejects.toBeInstanceOf(BusinessValidationError);
+
+    selectMock.mockResolvedValueOnce({ data: [{ forum_id: '   ' }], error: null });
+    await expect(sendToDiscord([[{ title: 'test' }]])).rejects.toBeInstanceOf(BusinessValidationError);
+
+    expect(postDiscordOrThrowMock).not.toHaveBeenCalled();
+  });
+
+  test('Round3: handleError sanitizes/redacts and truncates messages', async () => {
+    postDiscordOrThrowMock.mockResolvedValue(undefined);
+
+    const longMessage = `token leak https://x.test/webhook?secret=abc ${'x'.repeat(2000)}\nline2`;
+    await handleError([new Error(longMessage)]);
+
+    const [{ payload }] = postDiscordOrThrowMock.mock.calls[0];
+    expect(payload.content).toContain('[REDACTED_URL]');
+    expect(payload.content).not.toContain('https://x.test/webhook?secret=abc');
+    expect(payload.content.length).toBeLessThanOrEqual(1800);
+  });
+
+  test('Round3: main notifies business errors and rethrows non-business errors after notify', async () => {
+    fetchProductJsonMock.mockResolvedValue({ items: [] });
+    postDiscordOrThrowMock.mockResolvedValue(undefined);
+    await expect(main()).resolves.toBeUndefined();
+
+    const unknownError = new Error('internal\nstack\ttrace');
+    fetchWithRetryMock.mockRejectedValue(unknownError);
+    await expect(main()).rejects.toThrow('internal\nstack\ttrace');
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent leaking secrets and failing on unexpected Product Hunt or Supabase data by adding explicit validation and sanitization. 
- Make Discord posting more robust by validating thread ids, URL-encoding, and filtering unsafe image URLs. 
- Improve testability by avoiding auto-run in `test` env and adding unit tests for responsibilities.

### Description
- Introduce `BusinessValidationError` and add validation for `forum_id` in `getDiscordThreadId` and for Product Hunt payload shape via `validateProductHuntPayload` and `validateItemShape`.
- Add sanitization helpers: `sanitizeErrorMessage`, `truncateForDiscord`, `toSafeContentHtml`, and `isSafeImageUrl`, plus constants to limit lengths and allowed protocols.
- Make `fetchProductHuntData` use the new validator and ensure `extractImages` only returns safe image URLs and limits to 4 images; `formatDiscordMessages` now uses safe content handling and omits empty image fields.
- Strengthen `sendToDiscord` to validate its `embeds` argument, URL-encode the thread id, and export it for testing.
- Improve error reporting: `handleError` sanitizes/redacts and truncates messages before posting to the error webhook, and `main` aggregates errors, notifies, and rethrows non-business errors; `main` no longer auto-runs when `NODE_ENV === 'test'`.
- Export helpers and functions used by tests (`fetchProductHuntData`, `sendToDiscord`, `handleError`, `main`, `BusinessValidationError`).

### Testing
- Added `packages/getPopularProducts/tests/index.test.js` with Jest unit tests covering payload validation, `sendToDiscord` behavior and URL-encoding, error sanitization/truncation, and `main` error flow; all tests executed under `NODE_ENV=test` and passed. 
- Tests explicitly assert that `fetchWithRetry` is called, that `BusinessValidationError` is thrown for invalid payloads, that `postDiscordOrThrow` is called with an encoded `thread_id`, and that error content is redacted and truncated as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb5ed207288324b68e787620bfa755)